### PR TITLE
Add Qt GUI front end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
 # Tariq Alturkestani
 # Adaptive Parallelism for Scientific Applications
-# makefile for APlug stand alone driver 
+	# makefile for APlug stand alone driver 
 
 SRC = main.cpp 
 LIB = APlug.cpp 
 INC = APlug.h 
 
 main : ${SRC} ${LIB} ${INC}
-	g++ -o APlug -Wall -Wextra -O3 ${SRC} ${LIB} 
+		g++ -o APlug -Wall -Wextra -O3 ${SRC} ${LIB}
+
+GUI_SRC = gui/main_gui.cpp
+
+gui : ${GUI_SRC} ${LIB} ${INC}
+	g++ -o APlugGUI -std=c++11 -Wall -O3 ${GUI_SRC} ${LIB} \
+	$(shell pkg-config --cflags --libs Qt5Widgets)
+
+.PHONY: gui
 	
 clean:
-	rm -f APlug *.o
+		rm -f APlug APlugGUI *.o
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ Adaptive Parallelism for Scientific Applications
 		comma seperated values [NumberOfWorkers, TasksPerWorker, ParallelTime, SpeedupEfficiency]
 		
 	B-	"histogram.csv" 
-		[BucketNumber, TasksInBucket, StartTimeOfBucket, MiddleOfBucket]
-		note that you may also set the granularity of the buckets using the class member function setBucketsGranularity(num)
+[BucketNumber, TasksInBucket, StartTimeOfBucket, MiddleOfBucket]
+note that you may also set the granularity of the buckets using the class member function setBucketsGranularity(num)
+
+5- Graphical Interface:
+        A-      Build the GUI by running: make gui
+                This creates an executable named APlugGUI (Qt is required).
+        B-      Run ./APlugGUI and fill in the form fields:
+                number of tasks, sample size, sample file path,
+                minimum workers, maximum workers and step size.
+                Press "Run" to display recommendations and statistics.
 
 

--- a/gui/main_gui.cpp
+++ b/gui/main_gui.cpp
@@ -1,0 +1,117 @@
+#include <QApplication>
+#include <QMainWindow>
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTextEdit>
+#include <QFile>
+#include <QTextStream>
+#include <QMessageBox>
+#include "../APlug.h"
+
+class MainWindow : public QMainWindow {
+public:
+    MainWindow() {
+        QWidget *central = new QWidget;
+        QVBoxLayout *layout = new QVBoxLayout;
+        QFormLayout *form = new QFormLayout;
+
+        tasksEdit = new QLineEdit("0");
+        sampleSizeEdit = new QLineEdit("0");
+        sampleFileEdit = new QLineEdit;
+        minWorkersEdit = new QLineEdit("1");
+        maxWorkersEdit = new QLineEdit(QString::number(MAX_NUM_WORKERS));
+        stepEdit = new QLineEdit("15");
+
+        form->addRow("Number of tasks", tasksEdit);
+        form->addRow("Sample size", sampleSizeEdit);
+        form->addRow("Sample file path", sampleFileEdit);
+        form->addRow("Minimum workers", minWorkersEdit);
+        form->addRow("Maximum workers", maxWorkersEdit);
+        form->addRow("Step size", stepEdit);
+        layout->addLayout(form);
+
+        QPushButton *runBtn = new QPushButton("Run");
+        layout->addWidget(runBtn);
+
+        outputEdit = new QTextEdit;
+        outputEdit->setReadOnly(true);
+        layout->addWidget(outputEdit);
+
+        central->setLayout(layout);
+        setCentralWidget(central);
+        setWindowTitle("APlug GUI");
+
+        connect(runBtn, &QPushButton::clicked, this, [this]() { runAPlug(); });
+    }
+
+private:
+    void runAPlug() {
+        unsigned int numTasks = tasksEdit->text().toUInt();
+        unsigned int sampleSize = sampleSizeEdit->text().toUInt();
+        QString sampleFile = sampleFileEdit->text();
+        int minWorkers = minWorkersEdit->text().toInt();
+        int maxWorkers = maxWorkersEdit->text().toInt();
+        int step = stepEdit->text().toInt();
+
+        if (sampleFile.isEmpty()) {
+            QMessageBox::warning(this, "Input error", "Sample file path is empty");
+            return;
+        }
+
+        QFile file(sampleFile);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            QMessageBox::warning(this, "File error", "Cannot open sample file");
+            return;
+        }
+
+        QTextStream in(&file);
+        APlug plug;
+        while (!in.atEnd()) {
+            QString line = in.readLine();
+            plug.pushTime(line.toDouble());
+        }
+        file.close();
+
+        if (sampleSize == 0)
+            sampleSize = plug.getSampleSize();
+        if (numTasks == 0 || numTasks < sampleSize)
+            numTasks = sampleSize;
+
+        plug.setSampleSizeAndNumOfTasks(sampleSize, numTasks);
+        plug.getRecommendation(minWorkers, maxWorkers, step);
+
+        QString output;
+        output += QString("Number of tasks:  %1\n").arg(plug.getNumOfTasks());
+        output += QString("Sample size:      %1\n").arg(plug.getSampleSize());
+        output += QString("Sample sum:       %1\n").arg(plug.getSum());
+        output += QString("Sample min:       %1\n").arg(plug.getMin());
+        output += QString("Sample max:       %1\n").arg(plug.getMax());
+        output += QString("Sample mean:      %1\n").arg(plug.getMean());
+        output += QString("Sample stdev:     %1\n").arg(plug.getStdev());
+        output += QString("Estimated serial time (histogram): %1 sec\n").arg(plug.getEstSerialTimeSecHistogram());
+        output += QString("Estimated serial time (gamma): %1 sec\n").arg(plug.getEstSerialTimeSecGamma());
+        output += QString("Suggested max workers: %1\n").arg(plug.getMaxWorkers());
+        output += QString("Recommended number of workers: %1\n").arg(plug.getRecommendedNumOfWorkers());
+
+        outputEdit->setPlainText(output);
+    }
+
+    QLineEdit *tasksEdit;
+    QLineEdit *sampleSizeEdit;
+    QLineEdit *sampleFileEdit;
+    QLineEdit *minWorkersEdit;
+    QLineEdit *maxWorkersEdit;
+    QLineEdit *stepEdit;
+    QTextEdit *outputEdit;
+};
+
+int main(int argc, char *argv[]) {
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}
+


### PR DESCRIPTION
## Summary
- implement `gui/main_gui.cpp` as a simple Qt GUI for APlug
- extend Makefile with `gui` target and `.PHONY`
- document GUI build and usage in README

## Testing
- `make`
- `make gui` *(fails: `Qt5Widgets` not found)*
